### PR TITLE
Add scaladoc comments and make recipe for generating documentation

### DIFF
--- a/shell/configure_template
+++ b/shell/configure_template
@@ -68,7 +68,7 @@ TOUCH=touch -r
 `for i in ${VPATHDIRS}; do
     echo vpath %.scala \\$\(SCALAPATH\)/$i
 done`
-.PHONY: all help clean \$(MODULES)
+.PHONY: all help doc clean \$(MODULES)
 
 
 all: \$(TARGETS) \$(TEST_TARGETS)
@@ -127,6 +127,10 @@ help:
 	@for i in \$(MODULES) ; do \\
 	   echo \$\$i; \\
 	done
+
+doc:
+	sbt doc
+
 EOF
 ##################Hereafter some files you should not need to modify ################################
 


### PR DESCRIPTION
This PR adds example scaladoc comments and a make recipe for generating scaladoc documentation. Package-wide documentation needs to be in a file called `package.scala` which is not obvious so code for generating this file is included as well.