### PR TITLE
Use ChiselStage instead of Driver to generate verilog

### DIFF
--- a/shell/init_module.sh
+++ b/shell/init_module.sh
@@ -303,6 +303,7 @@ package ${PACKAGENAME}
 import chisel3._
 import chisel3.util._
 import chisel3.experimental._
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
 import dsptools.{DspTester, DspTesterOptionsManager, DspTesterOptions}
 import dsptools.numbers._
 import breeze.math.Complex
@@ -328,9 +329,10 @@ class ${MODULE}[T <:Data] (proto: T,n: Int) extends Module {
 
 /** This gives you verilog */
 object ${MODULE} extends App {
-    chisel3.Driver.execute(args, () => new ${MODULE}(
-        proto=DspComplex(UInt(16.W),UInt(16.W)), n=8)
-    )
+    val annos = Seq(ChiselGeneratorAnnotation(() => new ${MODULE}(
+        proto=DspComplex(UInt(16.W),UInt(16.W)), n=8
+    )))
+    (new ChiselStage).execute(args, annos)
 }
 
 /** This is a simple unit tester for demonstration purposes */


### PR DESCRIPTION
Chisel `Driver` has been deprecated since 3.2.4. I've been lately running into strange build issues where the chisel build fails and gives an empty error message instead of reporting the source of the problem. This happens at least while building `ACoreChip` and trying to connect IOs with different widths. Using `ChiselStage` seems to fix the issue.

cc @mkosunen 